### PR TITLE
Minor cleanup

### DIFF
--- a/frontend/views/about/AboutView.tsx
+++ b/frontend/views/about/AboutView.tsx
@@ -4,14 +4,12 @@ import { VerticalLayout } from "@vaadin/react-components/VerticalLayout.js";
 export default function AboutView() {
 
     return (
-        <VerticalLayout theme="padding spacing">
-            <h3>About View</h3>
-            <p>This is a simplified example on how to mix:
-                <ul>
-                    <li>Hilla with React</li>
-                    <li>Flow in pure Java</li>
-                </ul>
-            </p>
+        <VerticalLayout theme="padding">
+            <p>This project is a simplified example on how to mix:</p>
+            <ul>
+                <li>Hilla with React</li>
+                <li>Flow in pure Java</li>
+            </ul>
         </VerticalLayout>
     );
 }


### PR DESCRIPTION
Cleanup to get rid of `validateDOMNesting()` error in the About view (and to remove the header in this view as it looks weird).

![image](https://github.com/vaadin/flow-hilla-hybrid-example/assets/42799254/b98383f0-585a-444e-aa0a-3ccf3fc8a0bd)
