### PR TITLE
fix: fix document title signal handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@vaadin/vaadin-themable-mixin": "24.6.4",
         "@vaadin/vaadin-usage-statistics": "2.1.3",
         "construct-style-sheets-polyfill": "3.1.0",
+        "cross-spawn": "^7.0.6",
         "date-fns": "2.29.3",
         "lit": "3.2.1",
         "proj4": "2.12.1",
@@ -6051,9 +6052,10 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -15433,9 +15435,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -15905,7 +15907,7 @@
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
       "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
       "requires": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@vaadin/vaadin-themable-mixin": "24.6.4",
     "@vaadin/vaadin-usage-statistics": "2.1.3",
     "construct-style-sheets-polyfill": "3.1.0",
+    "cross-spawn": "^7.0.6",
     "date-fns": "2.29.3",
     "lit": "3.2.1",
     "proj4": "2.12.1",
@@ -125,7 +126,7 @@
       "workbox-core": "7.3.0",
       "workbox-precaching": "7.3.0"
     },
-    "hash": "bbdb1640e0c049515272577c44346eb6d4ba6e68cbe297e5465fe2ae490ab2f3"
+    "hash": "5da50cdfb38915456e53c66f67783bcfc57d048b99f7536de191a3fd3db4592a"
   },
   "overrides": {
     "@vaadin/bundles": "$@vaadin/bundles",
@@ -154,6 +155,7 @@
     "@vaadin/vaadin-themable-mixin": "$@vaadin/vaadin-themable-mixin",
     "@vaadin/vaadin-lumo-styles": "$@vaadin/vaadin-lumo-styles",
     "@vaadin/vaadin-material-styles": "$@vaadin/vaadin-material-styles",
-    "@playwright/test": "$@playwright/test"
+    "@playwright/test": "$@playwright/test",
+    "cross-spawn": "$cross-spawn"
   }
 }

--- a/src/main/frontend/views/@layout.tsx
+++ b/src/main/frontend/views/@layout.tsx
@@ -9,23 +9,30 @@ import {
 } from "@vaadin/react-components";
 import '@vaadin/icons';
 import Placeholder from 'Frontend/components/placeholder/Placeholder.js';
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from "../auth";
 import { createMenuItems, useViewConfig } from '@vaadin/hilla-file-router/runtime.js';
 import { effect, Signal, signal } from "@vaadin/hilla-react-signals";
 
-const vaadin = window.Vaadin as {
-    documentTitleSignal: Signal<string>;
-};
-vaadin.documentTitleSignal = signal("");
-//@ts-ignore
-effect(() =>  document.title = vaadin.documentTitleSignal.value);
+const documentTitleSignal = signal('');
+effect(() => {
+    document.title = documentTitleSignal.value;
+});
+
+// Publish for Vaadin to use
+(window as any).Vaadin.documentTitleSignal = documentTitleSignal;
 
 export default function Layout() {
+    const currentTitle = useViewConfig()?.title;
     const navigate = useNavigate();
     const location = useLocation();
-    vaadin.documentTitleSignal.value = useViewConfig()?.title ?? '';
+
+    useEffect(() => {
+        if (currentTitle) {
+            documentTitleSignal.value = currentTitle;
+        }
+    }, [currentTitle]);
 
 
     const { state, logout } = useAuth();
@@ -79,7 +86,7 @@ export default function Layout() {
 
             <DrawerToggle slot="navbar" aria-label="Menu toggle"></DrawerToggle>
             <h2 slot="navbar" className="text-l m-0">
-                {vaadin.documentTitleSignal}
+                {documentTitleSignal}
             </h2>
 
             <Suspense fallback={<Placeholder />}>


### PR DESCRIPTION
When clicking on a side nav link, an error related to the document title signal occurs:
Warning: Cannot update a component ('value') while rendering a different component ('Layout').
This change updates the document signal handling to prevent the error. The code is aligned with sources generated by start.vaadin.com.
