### PR TITLE
Remove unsupported lumoImports from theme.json

### DIFF
--- a/src/main/frontend/themes/my-theme/theme.json
+++ b/src/main/frontend/themes/my-theme/theme.json
@@ -1,3 +1,1 @@
-{
-  "lumoImports" : [ "typography", "color", "spacing", "badge", "utility" ]
-}
+{}


### PR DESCRIPTION
## Summary

`lumoImports` in `theme.json` is no longer supported in Vaadin 25.2. In 25.2.0-rc1 it breaks Lumo CSS loading, causing a blank page with `TypeError: Class extends value undefined` in the browser.

All Lumo modules now load automatically. The `lumoImports` property can be safely removed.

Closes #160