### PR TITLE
Increase FlowViewIT post-login wait timeout to 120s

### DIFF
--- a/src/test/java/org/vaadin/example/FlowViewIT.java
+++ b/src/test/java/org/vaadin/example/FlowViewIT.java
@@ -37,7 +37,7 @@ public class FlowViewIT {
         // page.waitForURL(Pattern.compile(BASE_URL + ".*"));
         page.waitForFunction("() => window.Vaadin?.Flow?.clients");
         page.locator("vaadin-vertical-layout").waitFor(
-                new Locator.WaitForOptions().setTimeout(60000) // 60 seconds
+                new Locator.WaitForOptions().setTimeout(120000) // 120 seconds
         );
     }
 


### PR DESCRIPTION
## Summary

- Increases the `waitFor` timeout on `vaadin-vertical-layout` in `FlowViewIT.setupTest` from 60s to 120s.
- With `testsInParallel=2` on CI, concurrent browser sessions slow down Vaadin's Flow bootstrap enough to exceed the previous 60s limit. The app itself starts fine, the other 4 tests pass: only the post-login rendering wait is the bottleneck.
- Mirrors the PiT workaround already applied in vaadin/platform-in-test-script@0262fec.

Closes #155